### PR TITLE
Expose nunjucks to the calling code

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,3 +33,5 @@ module.exports = function (options) {
 		cb();
 	});
 };
+
+module.exports.nunjucks = nunjucks;


### PR DESCRIPTION
This makes it easy for clients to [`configure`](http://mozilla.github.io/nunjucks/api.html#configure) Nunjucks.  
I needed it to specify template directory since it wasn't in the root folder.
