### PR TITLE
include gulp-data pipe

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@
 var gutil = require('gulp-util');
 var through = require('through2');
 var nunjucks = require('nunjucks');
+var data = require('gulp-data');
 
 module.exports = function (options) {
 	options = options || {};
@@ -10,6 +11,11 @@ module.exports = function (options) {
 		if (file.isNull()) {
 			this.push(file);
 			return cb();
+		}
+
+		if (file.data) {
+  			options = file.data;
+  			// or just options = _.extend(file.data, data) if you care to merge. Up to you.
 		}
 
 		if (file.isStream()) {

--- a/index.js
+++ b/index.js
@@ -14,8 +14,12 @@ module.exports = function (options) {
 		}
 
 		if (file.data) {
-  			options = file.data;
-  			// or just options = _.extend(file.data, data) if you care to merge. Up to you.
+  			//options = file.data;
+  			//custom objext.index for prototype
+  			options = file.data.results[0];
+  			//custom gulp log messages
+  			var fileName = file.path.toString();
+  			gutil.log('views | loaded gulp data for ' + fileName.split('/').pop());
 		}
 
 		if (file.isStream()) {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "gulp-nunjucks-render-data",
-  "version": "0.1.3",
-  "description": "Render Nunjucks templates",
+  "name": "gulp-nunjucks-render",
+  "version": "0.1.3.1",
+  "description": "Render Nunjucks templates with data",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gulp-nunjucks-render",
-  "version": "0.1.3.1",
+  "version": "0.1.4",
   "description": "Render Nunjucks templates with data",
   "license": "MIT",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,16 +1,11 @@
 {
-  "name": "gulp-nunjucks-render",
+  "name": "gulp-nunjucks-render-data",
   "version": "0.1.3",
   "description": "Render Nunjucks templates",
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git://github.com/carlosl/gulp-nunjucks-render"
-  },
-  "author": {
-    "name": "Carlos G. Limardo",
-    "email": "carlos.limardo@gmail.com",
-    "url": "http://limardo.org"
+    "url": "git://ryanluton/gulp-nunjucks-render.git"
   },
   "engines": {
     "node": ">=0.10.0"


### PR DESCRIPTION
Included the file.data attr from the gulp-data plugin

https://github.com/colynb/gulp-data

Verified working correctly when passing json into my generator-gulp-webapp project using nunjucks like so. 

```
gulp.task('views', function () {
  $.nunjucksRender.nunjucks.configure(['app/']);
  return gulp.src('app/*.html')
    .pipe(data(function() {
      return require('./mock-data.json');
    }))
    .pipe($.nunjucksRender())
    .pipe(gulp.dest('.tmp'))
});
```