### PR TITLE
Fix for #6 - Variables bleed between templates

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,6 @@ var _ = require('lodash');
 var gutil = require('gulp-util');
 var through = require('through2');
 var nunjucks = require('nunjucks');
-var data = require('gulp-data');
 
 module.exports = function (options) {
 	options = options || {};

--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ module.exports = function (options) {
 
     return through.obj(function (file, enc, cb) {
 
-        var data = _.extend(options, {});
+        var data = _.cloneDeep(options);
 
         if (file.isNull()) {
             this.push(file);
@@ -25,8 +25,6 @@ module.exports = function (options) {
             return cb();
         }
 
-
-        options.name = typeof options.name === 'function' && options.name(file) || file.relative;
         var _this = this;
         nunjucks.renderString(file.contents.toString(), data, function (err, result) {
             if (err) {

--- a/index.js
+++ b/index.js
@@ -5,36 +5,36 @@ var through = require('through2');
 var nunjucks = require('nunjucks');
 
 module.exports = function (options) {
-	options = options || {};
+    options = options || {};
 
-	return through.obj(function (file, enc, cb) {
-		if (file.isNull()) {
-			this.push(file);
-			return cb();
-		}
+    return through.obj(function (file, enc, cb) {
+        if (file.isNull()) {
+            this.push(file);
+            return cb();
+        }
 
-		if (file.data) {
+        if (file.data) {
             options = _.merge(file.data, options);
-		}
+        }
 
-		if (file.isStream()) {
-			this.emit('error', new gutil.PluginError('gulp-nunjucks', 'Streaming not supported'));
-			return cb();
-		}
+        if (file.isStream()) {
+            this.emit('error', new gutil.PluginError('gulp-nunjucks', 'Streaming not supported'));
+            return cb();
+        }
 
-		
-		options.name = typeof options.name === 'function' && options.name(file) || file.relative;
-		var _this = this;
-		nunjucks.renderString(file.contents.toString(), options, function (err, result) {
-			if (err) {
-				_this.emit('error', new gutil.PluginError('gulp-nunjucks', err));
-			}
-			file.contents = new Buffer(result);
-			file.path = gutil.replaceExtension(file.path, '.html');
-			_this.push(file);
-			cb();
-		});
-	});
+
+        options.name = typeof options.name === 'function' && options.name(file) || file.relative;
+        var _this = this;
+        nunjucks.renderString(file.contents.toString(), options, function (err, result) {
+            if (err) {
+                _this.emit('error', new gutil.PluginError('gulp-nunjucks', err));
+            }
+            file.contents = new Buffer(result);
+            file.path = gutil.replaceExtension(file.path, '.html');
+            _this.push(file);
+            cb();
+        });
+    });
 };
 
 module.exports.nunjucks = nunjucks;

--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 'use strict';
+var _ = require('lodash');
 var gutil = require('gulp-util');
 var through = require('through2');
 var nunjucks = require('nunjucks');
@@ -14,12 +15,7 @@ module.exports = function (options) {
 		}
 
 		if (file.data) {
-  			//options = file.data;
-  			//custom objext.index for prototype
-  			options = file.data.results[0];
-  			//custom gulp log messages
-  			var fileName = file.path.toString();
-  			gutil.log('views | loaded gulp data for ' + fileName.split('/').pop());
+            options = _.merge(file.data, options);
 		}
 
 		if (file.isStream()) {

--- a/index.js
+++ b/index.js
@@ -8,13 +8,16 @@ module.exports = function (options) {
     options = options || {};
 
     return through.obj(function (file, enc, cb) {
+
+        var data = _.extend(options, {});
+
         if (file.isNull()) {
             this.push(file);
             return cb();
         }
 
         if (file.data) {
-            options = _.merge(file.data, options);
+            data = _.merge(file.data, data);
         }
 
         if (file.isStream()) {
@@ -25,7 +28,7 @@ module.exports = function (options) {
 
         options.name = typeof options.name === 'function' && options.name(file) || file.relative;
         var _this = this;
-        nunjucks.renderString(file.contents.toString(), options, function (err, result) {
+        nunjucks.renderString(file.contents.toString(), data, function (err, result) {
             if (err) {
                 _this.emit('error', new gutil.PluginError('gulp-nunjucks', err));
             }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git://ryanluton/gulp-nunjucks-render.git"
+    "url": "git://github.com/carlosl/gulp-nunjucks-render"
   },
   "engines": {
     "node": ">=0.10.0"

--- a/package.json
+++ b/package.json
@@ -28,8 +28,9 @@
   ],
   "dependencies": {
     "gulp-util": "~2.2.0",
-    "through2": "~0.4.0",
-    "nunjucks": "~1.1.0"
+    "lodash": "^3.3.0",
+    "nunjucks": "~1.1.0",
+    "through2": "~0.4.0"
   },
   "devDependencies": {
     "mocha": "*"

--- a/readme.md
+++ b/readme.md
@@ -30,6 +30,30 @@ gulp.task('default', function () {
 
 *Note: To keep Nunjucks render from eating up all your ram, make sure to specify your watch path. ```nunjucksRender.nunjucks.configure(['src/path/to/templates/']);``` This will also allow you to define your paths relatively.*
 
+
+## Example with gulp data
+
+```js
+var gulp = require('gulp');
+var nunjucksRender = require('gulp-nunjucks-render');
+var data = require('gulp-data');
+
+function getDataForFile(file){
+    return {
+        example: 'data loaded for ' + file.relative
+    };
+}
+
+gulp.task('default', function () {
+	nunjucksRender.nunjucks.configure(['src/templates/']);
+	return gulp.src('src/templates/*.html')
+	    .pipe(data(getDataForFile))
+		.pipe(nunjucksRender())
+		.pipe(gulp.dest('dist'));
+});
+```
+
+
 ## API
 
 ### nunjucks-render(context)


### PR DESCRIPTION
For review - (optimistically) builds on #14 

In a nutshell, it's using _.cloneDeep to create a new data context for each file.

https://github.com/at0g/gulp-nunjucks-render/blob/hotfix/variable-bleed/index.js#L12

I believe that by using the same `options` object (passed by reference), calls to `{% set ... %}` are updating the shared context and causing the values to bleed across files.

