### PR TITLE
Add options.ext to configure resulting extension

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,6 +6,9 @@ var nunjucks = require('nunjucks');
 
 module.exports = function (options) {
     options = options || {};
+    if (!options.ext) {
+        options.ext = '.html';
+    }
 
     return through.obj(function (file, enc, cb) {
 
@@ -31,7 +34,7 @@ module.exports = function (options) {
                 _this.emit('error', new gutil.PluginError('gulp-nunjucks', err));
             }
             file.contents = new Buffer(result);
-            file.path = gutil.replaceExtension(file.path, '.html');
+            file.path = gutil.replaceExtension(file.path, options.ext);
             _this.push(file);
             cb();
         });


### PR DESCRIPTION
For use in cases where one might want to output a file as something other than '.html'.  Our use case is in generating Wordpress themes -- they're all fairly similar, so we use Nunjucks + Gulp to abstract out the differences, and compile them together.  For this, we'd want the resulting build files to be .php instead of .html.  While we could add something to the gulp stream to rename these files, ideally the '.html' wouldn't be hardcoded.

Thanks!