### PR TITLE
Fix gulp never terminating on node 0.12 & nunjucks 1.2.0+

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@ var _ = require('lodash');
 var gutil = require('gulp-util');
 var through = require('through2');
 var nunjucks = require('nunjucks');
+nunjucks.configure({ watch: false });
 
 module.exports = function (options) {
     options = options || {};

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gulp-nunjucks-render",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Render Nunjucks templates with data",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
Please see this issue:
https://github.com/mozilla/nunjucks/issues/369

There are other related issues due to this problem with 1.2.0. An unreleased version of the lib resolves this by making watch:false the default