### PR TITLE
Update nunjucks lib to allows for latest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "dependencies": {
     "gulp-util": "~2.2.0",
     "lodash": "^3.3.0",
-    "nunjucks": "~1.2.0",
+    "nunjucks": "^1.2.0",
     "through2": "~0.4.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Adding `^1.2.0` allows for support of new releases (`1.3.4` is the latest) as well as any release in between (down to `1.2.0`). The nunjucks library is following semver, so this should be a safe change.