### PR TITLE
Add error filename to PluginError object

### DIFF
--- a/index.js
+++ b/index.js
@@ -42,10 +42,13 @@ module.exports = function (options, loaders, env ) {
         }
 
         var _this = this;
+
+        var filePath = file.path;
+
         try {
             compile.renderString(file.contents.toString(), data, function (err, result) {
                 if (err) {
-                  _this.emit('error', new gutil.PluginError('gulp-nunjucks', err));
+                  _this.emit('error', new gutil.PluginError('gulp-nunjucks', err, {fileName: filePath}));
                   return cb();
                 }
                 file.contents = new Buffer(result);
@@ -55,7 +58,7 @@ module.exports = function (options, loaders, env ) {
                 cb();
             });
         } catch (err) {
-            _this.emit('error', new gutil.PluginError('gulp-nunjucks', err));
+            _this.emit('error', new gutil.PluginError('gulp-nunjucks', err, {fileName: filePath}));
             cb();
         }
     });

--- a/test/fixtures/import-error.nunj
+++ b/test/fixtures/import-error.nunj
@@ -1,0 +1,1 @@
+{% import "fake-file.html" as nope %}

--- a/test/main.js
+++ b/test/main.js
@@ -154,4 +154,46 @@ describe('gulp-nunjucks-render', function(){
 
     });
 
+    it('should throw an error', function(done) {
+        var stream = nunjucksRender();
+        var file = getFile('fixtures/import-error.nunj');
+
+        var onerror = function(err) {
+            should.exist(err);
+            this.removeListener('finish', onfinish);
+            done();
+        };
+
+        var onfinish = function() {
+            done(new Error("Template has a syntax error which wasn't thrown."));
+        };
+
+        stream.on('error', onerror);
+        stream.on('finish', onfinish);
+
+        stream.write(file);
+        stream.end();
+    });
+
+    it('error should contain file path', function(done) {
+        var stream = nunjucksRender();
+        var file = getFile('fixtures/import-error.nunj');
+
+        var onerror = function(err) {
+            should.exist(err);
+            err.should.have.property('fileName');
+            this.removeListener('finish', onfinish);
+            done();
+        };
+
+        var onfinish = function() {
+            done(new Error("Template has a syntax error which wasn't thrown."));
+        };
+
+        stream.on('error', onerror);
+        stream.on('finish', onfinish);
+
+        stream.write(file);
+        stream.end();
+    });
 });


### PR DESCRIPTION
This PR adds the `file.path` of the file throwing nunjucks errors into the gulp-util `PluginError` object. Basically copies what's going on in [gulp-nunjucks](https://github.com/sindresorhus/gulp-nunjucks) on lines [21](https://github.com/sindresorhus/gulp-nunjucks/blob/997a25099704796203d9c0364c0046e82b028ea9/index.js#L21) and [29](https://github.com/sindresorhus/gulp-nunjucks/blob/997a25099704796203d9c0364c0046e82b028ea9/index.js#L29).

Also adds two simple tests, just because.