### PR TITLE
Updated nunjucks version to 2.0.0 as minimum, allowed Windows to run Mocha tests properly too

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "dependencies": {
     "gulp-util": "~2.2.0",
     "lodash": "^3.3.0",
-    "nunjucks": "^1.2.0",
+    "nunjucks": "^2.0.0",
     "through2": "~0.4.0"
   },
   "devDependencies": {

--- a/test/main.js
+++ b/test/main.js
@@ -133,14 +133,14 @@ describe('gulp-nunjucks-render', function(){
             // First file
             should.exist(output);
             should.exist(output.contents);
-            output.path.should.equal('fixtures/set.html');
+            output.path.should.equal(path.normalize('fixtures/set.html'));
             output.contents.toString().should.equal(expected1);
 
             stream.once('data', function(output){
                 // Second file
                 should.exist(output);
                 should.exist(output.contents);
-                output.path.should.equal('fixtures/hello-world.html');
+                output.path.should.equal(path.normalize('fixtures/hello-world.html'));
                 output.contents.toString().should.equal(expected2);
             });
 


### PR DESCRIPTION
As title states. Furthermore fixes issues running tests on Windows machines, reference [here](https://github.com/carrot/roots-client-templates/issues/12).