### PR TITLE
compiles to the same file extension

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,6 +7,12 @@ nunjucks.configure({ watch: false });
 
 module.exports = function (options, loaders, env ) {
     options = options || {};
+    // ext = output file extension		
+    // Check if output file extension is mentioned or not		
+    if (options.ext === undefined) {		
+        // Apply default output extension		
+        options.ext = '.html';		
+    }
 
     var compile = nunjucks;
     if( loaders || env ){
@@ -46,8 +52,8 @@ module.exports = function (options, loaders, env ) {
                   return cb();
                 }
                 file.contents = new Buffer(result);
-                // if options.ext is not mentioned
-                if(options.ext === undefined){
+                // if extension needed to be inherited
+                if(options.inheritExtension){
                     // Then apply the same extension 
                     options.ext = filePath.substr(filePath.lastIndexOf("."));
                 }

--- a/index.js
+++ b/index.js
@@ -7,12 +7,6 @@ nunjucks.configure({ watch: false });
 
 module.exports = function (options, loaders, env ) {
     options = options || {};
-    // ext = output file extension
-    // Check if output file extension is mentioned or not
-    if (options.ext === undefined) {
-        // Apply default output extension
-        options.ext = '.html';
-    }
 
     var compile = nunjucks;
     if( loaders || env ){
@@ -52,8 +46,13 @@ module.exports = function (options, loaders, env ) {
                   return cb();
                 }
                 file.contents = new Buffer(result);
+                // if options.ext is not mentioned
+                if(options.ext === undefined){
+                    // Then apply the same extension 
+                    options.ext = filePath.substr(filePath.lastIndexOf("."));
+                }
                 // output file with the mentioned/default extension
-                file.path = gutil.replaceExtension(file.path, options.ext);
+                file.path = gutil.replaceExtension(filePath, options.ext);
                 _this.push(file);
                 cb();
             });


### PR DESCRIPTION
I was having hard time on compiling files to more than one extension. For example, I have three files, one with .php extension (having html + php code in it) and other two with .html extension. When I compiled these files, all three files were compiling with extension .html. So instead, I made modifications which will let the files to compile as it is with the user provided extension when the user hadn't mention the "ext" option.