### PR TITLE
Allow to configure default options for multiple rendering

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,8 +4,7 @@ var gutil = require('gulp-util');
 var through = require('through2');
 var nunjucks = require('nunjucks');
 
-module.exports = function (options) {
-  var defaults = {
+var defaults = {
     path: '.',
     ext: '.html',
     data: {},
@@ -14,7 +13,9 @@ module.exports = function (options) {
       watch: false
     },
     manageEnv: null
-  }
+};
+
+module.exports = function (options) {
   options = _.defaultsDeep(options || {}, defaults);
   nunjucks.configure(options.envOptions);
 
@@ -73,6 +74,10 @@ module.exports = function (options) {
       cb();
     }
   });
+};
+
+module.exports.setDefaults = function (options) {
+  defaults = _.defaultsDeep(options || {}, defaults);
 };
 
 module.exports.nunjucks = nunjucks;

--- a/test/expected/global-not-excaped.html
+++ b/test/expected/global-not-excaped.html
@@ -1,0 +1,1 @@
+<strong>Hello World!</strong>

--- a/test/main.js
+++ b/test/main.js
@@ -272,4 +272,50 @@ describe('gulp-nunjucks-render', function(){
     stream.write(file);
     stream.end();
   });
+
+  it('should use custom default config', function(done){
+    var customNunjucksRender = require('../');
+
+    customNunjucksRender.setDefaults({
+      envOptions: {
+        autoescape: true
+      }
+    });
+
+    var streamAutoescape = customNunjucksRender({
+      data: {
+        html: '<strong>Hello World!</strong>'
+      }
+    });
+
+    var fileAutoescape = getFile('fixtures/global.nunj');
+    var fileNotAutoescape = getFile('fixtures/global.nunj');
+    var expectedAutoescape = getExpected('global.html');
+    var expectedNotAutoescape = getExpected('global-not-excaped.html');
+
+    streamAutoescape.once('data', function(output) {
+      output.contents.toString().should.equal(expectedAutoescape);
+
+      customNunjucksRender.setDefaults({
+        envOptions: {
+          autoescape: false
+        }
+      });
+
+      var streamNotAutoescape = customNunjucksRender({
+        data: {
+          html: '<strong>Hello World!</strong>'
+        }
+      });
+
+      streamNotAutoescape.once('data', function(output) {
+        output.contents.toString().should.equal(expectedNotAutoescape);
+        done();
+      });
+      streamNotAutoescape.write(fileNotAutoescape);
+      streamNotAutoescape.end();
+    });
+    streamAutoescape.write(fileAutoescape);
+    streamAutoescape.end();
+  });
 });


### PR DESCRIPTION
Hello Carlos,
What do you think about configurable default options?
I implemented this for multiple rendering:
```javascript
var nunjucksRender = require('gulp-nunjucks-render');

template1.pipe(nunjucksRender({
  path: ['/templates'], // repeat or merge with different 'data' property
  envOptions: {         
    autoescape: false
  },
  data: {...}
}));
...
templateN.pipe(nunjucksRender({
  path: ['/templates'], // repeat or merge with different 'data' property
  envOptions: {
    autoescape: false
  },
  data: {...}
}));
```

Will be replaced with:
```javascript
var nunjucksRender = require('gulp-nunjucks-render');

nunjucksRender.setDefaults({
  path: ['/templates'],
  envOptions: {
    autoescape: false
  }
});

template1.pipe(nunjucksRender({data: {...}}));
...
templateN.pipe(nunjucksRender({data: {...}}));
```

Thank you.