### PR TITLE
Fix TypeError:"_.defaultsDeep is not a function"(lodash)

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   ],
   "dependencies": {
     "gulp-util": "~2.2.0",
-    "lodash": "^3.3.0",
+    "lodash": "^3.10.0",
     "nunjucks": "^2.0.0",
     "through2": "~0.4.0"
   },


### PR DESCRIPTION
This happens when in the project has another plugin use lodash <= `3.3.0` < `v.3.10.0`

Example:
`gulp-nunjucks-render` - in dep lodash `^v.3.3.0`
`<foo-gulp-plugin>` - in dep lodash `=v.3.5.0`
 |
V
npm install lodash `v.3.5.0`

But `defaultsDeep` was added in version 3.10.0 => TypeError `_.defaultsDeep is not a function`
