### PR TITLE
Replace deprecated dependency gulp-util

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 'use strict';
 var _ = require('lodash');
-var gutil = require('gulp-util');
+var PluginError = require('plugin-error');
+var replaceExtension = require('replace-ext');
 var through = require('through2');
 var nunjucks = require('nunjucks');
 
@@ -46,7 +47,7 @@ module.exports = function (options) {
     }
 
     if (file.isStream()) {
-      this.emit('error', new gutil.PluginError('gulp-nunjucks', 'Streaming not supported'));
+      this.emit('error', new PluginError('gulp-nunjucks', 'Streaming not supported'));
       return cb();
     }
 
@@ -57,20 +58,20 @@ module.exports = function (options) {
     try {
       compile.renderString(file.contents.toString(), data, function (err, result) {
         if (err) {
-          _this.emit('error', new gutil.PluginError('gulp-nunjucks', err, {fileName: filePath}));
+          _this.emit('error', new PluginError('gulp-nunjucks', err, {fileName: filePath}));
           return cb();
         }
         file.contents = new Buffer(result);
         // Replace extension with mentioned/default extension
         // only if inherit extension flag is not provided(truthy)
         if (!options.inheritExtension) {
-          file.path = gutil.replaceExtension(filePath, options.ext);
+          file.path = replaceExtension(filePath, options.ext);
         }
         _this.push(file);
         cb();
       });
     } catch (err) {
-      _this.emit('error', new gutil.PluginError('gulp-nunjucks', err, {fileName: filePath}));
+      _this.emit('error', new PluginError('gulp-nunjucks', err, {fileName: filePath}));
       cb();
     }
   });

--- a/package.json
+++ b/package.json
@@ -27,14 +27,16 @@
     "javascript"
   ],
   "dependencies": {
-    "gulp-util": "~2.2.0",
     "lodash": "^3.10.0",
     "nunjucks": "^3.0.0",
+    "plugin-error": "^0.1.2",
+    "replace-ext": "^1.0.0",
     "through2": "~0.4.0"
   },
   "devDependencies": {
     "mocha": "^2.1.0",
-    "should": "^5.0.1"
+    "should": "^5.0.1",
+    "vinyl": "^2.1.0"
   },
   "readmeFilename": "readme.md",
   "bugs": {

--- a/test/main.js
+++ b/test/main.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var should = require('should');
-var gutil = require('gulp-util');
+var Vinyl = require('vinyl');
 var nunjucksRender = require('../');
 var fs = require('fs');
 var path = require('path');
@@ -9,7 +9,7 @@ var path = require('path');
 require('mocha');
 
 function getFile(filepath){
-  return new gutil.File({
+  return new Vinyl({
     base: 'test/fixtures',
     cwd: 'test',
     path: filepath,


### PR DESCRIPTION
[`gulp-util`](https://www.npmjs.com/package/gulp-util) has been deprecated recently. Continuing to use this dependency may prevent the use of your library with the latest release of Gulp 4 so it is important to replace `gulp-util`.